### PR TITLE
SCT-1394 End to end alignments work.

### DIFF
--- a/src/us/kbase/genehomology/core/Namespace.java
+++ b/src/us/kbase/genehomology/core/Namespace.java
@@ -51,7 +51,7 @@ public class Namespace {
 	/** Get the database associated with the namespace.
 	 * @return the sketch database.
 	 */
-	public GeneHomologyDatabase getSketchDatabase() {
+	public GeneHomologyDatabase getDatabase() {
 		return homologyDatabase;
 	}
 

--- a/src/us/kbase/genehomology/core/exceptions/NoSuchNamespaceException.java
+++ b/src/us/kbase/genehomology/core/exceptions/NoSuchNamespaceException.java
@@ -1,0 +1,15 @@
+package us.kbase.genehomology.core.exceptions;
+
+/** Thrown when the specified namespace does not exist.
+ * @author gaprice@lbl.gov
+ *
+ */
+@SuppressWarnings("serial")
+public class NoSuchNamespaceException extends NoDataException {
+
+	//TODO TEST
+	
+	public NoSuchNamespaceException(final String message) {
+		super(ErrorType.NO_SUCH_NAMESPACE, message);
+	}
+}

--- a/src/us/kbase/genehomology/homology/last/LAST.java
+++ b/src/us/kbase/genehomology/homology/last/LAST.java
@@ -47,13 +47,20 @@ public class LAST {
 		}
 	}
 	
+	// TODO NOW this should take a genome homology DB
 	public List<SequenceSearchResult> search(final Path searchDB, final Path queryFasta)
 			throws GeneHomologyImplementationException {
 		Path tempFile = null;
-		// check .prj file exists for searchDB
+		final String searchDBStr;
+		if (searchDB.toString().endsWith(".prj")) {
+			searchDBStr = searchDB.toString().substring(0, searchDB.toString().length() - 4);
+		} else {
+			searchDBStr = searchDB.toString();
+		}
+		// TODO NOW check .prj file exists for searchDBStr
 		try {
 			tempFile = Files.createTempFile(tempFileDirectory, "mash_output", ".tmp");
-			runLASTToOutputFile(tempFile, searchDB.toString(), queryFasta.toString());
+			runLASTToOutputFile(tempFile, searchDBStr, queryFasta.toString());
 			return processLASTOutput(tempFile);
 			// all of the below is really hard to test
 		} catch (IOException e) {

--- a/src/us/kbase/genehomology/service/Fields.java
+++ b/src/us/kbase/genehomology/service/Fields.java
@@ -1,0 +1,79 @@
+package us.kbase.genehomology.service;
+
+/** Field names used in incoming and outgoing data structures.
+ * @author gaprice@lbl.gov
+ *
+ */
+public class Fields {
+
+	/* root */
+	
+	/** The server name. */
+	public static final String SERVER_NAME = "servname";
+	/** The version of the service. */
+	public static final String VERSION = "version";
+	/** The time, in milliseconds since the epoch, at the service. */
+	public static final String SERVER_TIME = "servertime";
+	/** The Git commit from which the service was built. */
+	public static final String GIT_HASH = "gitcommithash";
+	
+	/* namespaces */
+	
+	/** An ID for a namespace. */
+	public static final String NAMESPACE_ID = "id";
+	/** The authentication source associated with a namespace. */
+	public static final String NAMESPACE_AUTH_SOURCE = "authsource";
+	/** A description for a namespace. */
+	public static final String NAMESPACE_DESCRIPTION = "desc";
+	/** The last modification date of the namespace. */
+	public static final String NAMESPACE_LASTMOD = "lastmod";
+	/** The implementation used to create the database associated with a namespace.
+	 */
+	public static final String NAMESPACE_IMPLEMENTATION = "impl";
+	/** The number of sequences in a namespace sketch database. */
+	public static final String NAMESPACE_SEQ_COUNT = "seqcount";
+	/** The ID of the data source where the sequences in a namespace sketch database originated. */
+	public static final String NAMESPACE_DATA_SOURCE_ID = "datasource";
+	/** The ID of the database within the data source where the sequences in a namespace
+	 * sketch database originated.
+	 */
+	public static final String NAMESPACE_DB_ID = "database";
+	
+	/* Aligment results */
+	/** A set of alignments from a query sequence to one or more reference sequences. */
+	public static final String ALIGNMENTS = "alignments";
+	/** The implementation used to calculate the alignements. */
+	public static final String ALIGN_IMPLEMENTATION = "impl";
+	/** A set of namespaces. */
+	public static final String ALIGN_NAMESPACES = "namespaces";
+	/** The alignment e-value. */
+	public static final String ALIGN_E_VAL = "evalue";
+	/** The ID of the first sequence. */
+	public static final String ALIGN_SEQ1_ID = "id1";
+	/** The aligned first sequence. */
+	public static final String ALIGN_SEQ1_SEQ = "alignseq1";
+	/** The length of the first sequence. */
+	public static final String ALIGN_SEQ1_LEN = "lenseq1";
+	/** The start of the alignment for first sequence. */
+	public static final String ALIGN_SEQ1_ALIGN_START = "alignstart1";
+	/** The length of the alignment for first sequence. */
+	public static final String ALIGN_SEQ1_ALIGN_LEN = "alignlen1";
+	
+	/** The ID of the second sequence. */
+	public static final String ALIGN_SEQ2_ID = "id2";
+	/** The aligned second sequence. */
+	public static final String ALIGN_SEQ2_SEQ = "alignseq2";
+	/** The length of the second sequence. */
+	public static final String ALIGN_SEQ2_LEN = "lenseq2";
+	/** The start of the alignment for second sequence. */
+	public static final String ALIGN_SEQ2_ALIGN_START = "alignstart2";
+	/** The length of the alignment for second sequence. */
+	public static final String ALIGN_SEQ2_ALIGN_LEN = "alignlen2";
+	
+	/* errors */
+	
+	/** An error. */
+	public static final String ERROR = "error";
+	
+	
+}

--- a/src/us/kbase/genehomology/service/GeneHomologyService.java
+++ b/src/us/kbase/genehomology/service/GeneHomologyService.java
@@ -22,7 +22,7 @@ public class GeneHomologyService extends ResourceConfig {
 	
 	@SuppressWarnings("unused")
 	private final SLF4JAutoLogger logger; //keep a reference to prevent GC
-	// TODO *NOW use java-fasta-utils to check fasta format & check only 1 query
+	// TODO NOWNOW use java-fasta-utils to check fasta format & check only 1 query
 	
 	public GeneHomologyService()
 			throws GeneHomologyConfigurationException {

--- a/src/us/kbase/genehomology/service/api/Namespaces.java
+++ b/src/us/kbase/genehomology/service/api/Namespaces.java
@@ -1,0 +1,191 @@
+package us.kbase.genehomology.service.api;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.StandardCopyOption;
+import java.time.Instant;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import javax.inject.Inject;
+import javax.servlet.http.HttpServletRequest;
+import javax.ws.rs.GET;
+import javax.ws.rs.POST;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.Context;
+import javax.ws.rs.core.MediaType;
+
+import us.kbase.genehomology.config.GeneHomologyConfig;
+import us.kbase.genehomology.core.DataSourceID;
+import us.kbase.genehomology.core.Namespace;
+import us.kbase.genehomology.core.NamespaceID;
+import us.kbase.genehomology.core.exceptions.IllegalParameterException;
+import us.kbase.genehomology.core.exceptions.MissingParameterException;
+import us.kbase.genehomology.core.exceptions.NoSuchNamespaceException;
+import us.kbase.genehomology.homology.GeneHomologyDBLocation;
+import us.kbase.genehomology.homology.GeneHomologyDBName;
+import us.kbase.genehomology.homology.GeneHomologyDatabase;
+import us.kbase.genehomology.homology.GeneHomologyImplementationException;
+import us.kbase.genehomology.homology.GeneHomologyImplementationName;
+import us.kbase.genehomology.homology.SequenceSearchResult;
+import us.kbase.genehomology.homology.last.LAST;
+import us.kbase.genehomology.service.Fields;
+
+/** Handler for the endpoints under the {@link ServicePaths#NAMESPACE_ROOT} endpoints.
+ * @author gaprice@lbl.gov
+ *
+ */
+@javax.ws.rs.Path(ServicePaths.NAMESPACE_ROOT)
+public class Namespaces {
+	
+	//TODO NOWNOW error handler not working
+
+	private final java.nio.file.Path tempDir;
+	private static final Namespace ns;
+	static {
+		try {
+			ns = Namespace.getBuilder(
+					new NamespaceID("testns"),
+					new GeneHomologyDatabase(
+							new GeneHomologyDBName("testns"),
+							new GeneHomologyImplementationName("last"),
+							new GeneHomologyDBLocation(Paths.get(
+									"/media/mongohd/genehom/LAST/uniref50_40Mlines.last.prj")),
+							6000000),
+					Instant.now())
+					.withNullableDataSourceID(new DataSourceID("ds"))
+					.withNullableDescription("desc")
+					.withNullableSourceDatabaseID("sourcedb")
+					.build();
+		} catch (Exception e) {
+			throw new RuntimeException(e.getMessage(), e);
+		}
+	}
+	
+	/** Construct the handler. This is typically done by the Jersey framework.
+	 * @param cfg the configuration for the gene homology service.
+	 */
+	@Inject
+	public Namespaces(final GeneHomologyConfig cfg) {
+		this.tempDir = cfg.getPathToTemporaryFileDirectory();
+	}
+
+	/** Get the extant namespaces.
+	 * @return the namespaces in the system.
+	 */
+	@GET
+	@Produces(MediaType.APPLICATION_JSON)
+	public Set<Map<String, Object>> getNamespaces() {
+		return new HashSet<>(Arrays.asList(fromNamespace(ns)));
+	}
+	
+	/** Get a particular namespace.
+	 * @param namespace the ID of the namespace.
+	 * @return the namespace.
+	 * @throws NoSuchNamespaceException if there is no such namespace.
+	 * @throws MissingParameterException if the ID is missing or white space only.
+	 * @throws IllegalParameterException if the ID is not a valid namespace ID.
+	 */
+	@GET
+	@Produces(MediaType.APPLICATION_JSON)
+	@javax.ws.rs.Path(ServicePaths.NAMESPACE_SELECT)
+	public Map<String, Object> getNamespace(
+			@PathParam(ServicePaths.NAMESPACE_SELECT_PARAM) final String namespace)
+			throws NoSuchNamespaceException, MissingParameterException,
+				IllegalParameterException {
+		final NamespaceID nsid = new NamespaceID(namespace);
+		if (!nsid.equals(ns.getID())) {
+			throw new NoSuchNamespaceException(namespace);
+		}
+		return fromNamespace(ns);
+	}
+
+	private Map<String, Object> fromNamespace(final Namespace ns) {
+		final Map<String, Object> ret = new HashMap<>();
+		ret.put(Fields.NAMESPACE_DESCRIPTION, ns.getDescription().orNull());
+		ret.put(Fields.NAMESPACE_ID, ns.getID().getName());
+		ret.put(Fields.NAMESPACE_LASTMOD, ns.getModification().toEpochMilli());
+		ret.put(Fields.NAMESPACE_IMPLEMENTATION, ns.getDatabase()
+				.getImplementationName().getName());
+		ret.put(Fields.NAMESPACE_SEQ_COUNT, ns.getDatabase().getSequenceCount());
+		ret.put(Fields.NAMESPACE_DB_ID, ns.getSourceDatabaseID());
+		ret.put(Fields.NAMESPACE_DATA_SOURCE_ID, ns.getSourceID().getName());
+		return ret;
+	}
+	
+	/** Search a namespace. Expects a fasta file with one sequence in the request body.
+	 * @param request the incoming servlet request.
+	 * @param namespace a namespace ID.
+	 * @return the matches.
+	 * @throws IOException if an error occurs retrieving the fasta file from the
+	 * request or saving the file to a temporary file.
+	 * @throws NoSuchNamespaceException if the requested namespace does not exist.
+	 * @throws MissingParameterException if the namespace ID parameter is missing.
+	 * @throws IllegalParameterException if namespace ID is illegal.
+	 * @throws GeneHomologyImplementationException if the homology implementation throws an
+	 * error.
+	 */
+	@POST
+	@Produces(MediaType.APPLICATION_JSON)
+	@javax.ws.rs.Path(ServicePaths.NAMESPACE_SEARCH)
+	public Map<String, Object> searchNamespaces(
+			@Context HttpServletRequest request,
+			@PathParam(ServicePaths.NAMESPACE_SELECT_PARAM) final String namespace)
+			throws IOException, NoSuchNamespaceException, MissingParameterException,
+				IllegalParameterException, GeneHomologyImplementationException {
+		final NamespaceID nsid = new NamespaceID(namespace);
+		if (!nsid.equals(ns.getID())) {
+			throw new NoSuchNamespaceException(namespace);
+		}
+		Path tempFile = null;
+		final List<SequenceSearchResult> seqs;
+		// should catch IOException and do something with it?
+		try (final InputStream is = request.getInputStream()) {
+			tempFile = Files.createTempFile(tempDir, "genehomol_input", ".tmp.fasta");
+			Files.copy(is, tempFile, StandardCopyOption.REPLACE_EXISTING);
+			seqs = new LAST(tempDir, 120).search(
+					ns.getDatabase().getLocation().getPathToFile().get(), tempFile);
+		} finally {
+			if (tempFile != null) {
+				Files.delete(tempFile);
+			}
+		}
+		//TODO NOW add impl version
+		final Map<String, Object> ret = new HashMap<>();
+		ret.put(Fields.ALIGN_NAMESPACES, new HashSet<>(Arrays.asList(fromNamespace(ns))));
+		ret.put(Fields.ALIGN_IMPLEMENTATION, ns.getDatabase().getImplementationName().getName());
+		ret.put(Fields.ALIGNMENTS, seqs.stream()
+				.map(s -> fromSearchResult(s))
+				.collect(Collectors.toList()));
+		return ret;
+	}
+
+
+	private Map<String, Object> fromSearchResult(final SequenceSearchResult ssr) {
+		final Map<String, Object> ret = new HashMap<>();
+		ret.put(Fields.ALIGN_E_VAL, ssr.getEValue());
+		
+		ret.put(Fields.ALIGN_SEQ1_ID, ssr.getSequence1().getId());
+		ret.put(Fields.ALIGN_SEQ1_SEQ, ssr.getSequence1().getAlignedSequence());
+		ret.put(Fields.ALIGN_SEQ1_LEN, ssr.getSequence1().getSequenceLength());
+		ret.put(Fields.ALIGN_SEQ1_ALIGN_START, ssr.getSequence1().getAlignmentStart());
+		ret.put(Fields.ALIGN_SEQ1_ALIGN_LEN, ssr.getSequence1().getAlignmentLength());
+		
+		ret.put(Fields.ALIGN_SEQ2_ID, ssr.getSequence2().getId());
+		ret.put(Fields.ALIGN_SEQ2_SEQ, ssr.getSequence2().getAlignedSequence());
+		ret.put(Fields.ALIGN_SEQ2_LEN, ssr.getSequence2().getSequenceLength());
+		ret.put(Fields.ALIGN_SEQ2_ALIGN_START, ssr.getSequence2().getAlignmentStart());
+		ret.put(Fields.ALIGN_SEQ2_ALIGN_LEN, ssr.getSequence2().getAlignmentLength());
+		return ret;
+	}
+	
+}

--- a/src/us/kbase/genehomology/service/api/Root.java
+++ b/src/us/kbase/genehomology/service/api/Root.java
@@ -10,12 +10,14 @@ import javax.ws.rs.core.MediaType;
 
 import com.google.common.collect.ImmutableMap;
 
+import us.kbase.genehomology.service.Fields;
+
 /** The root of the server - returns basic information about the service, like
  * the server name, the version, the server local time, and the git hash from the build.
  * @author gaprice@lbl.gov
  *
  */
-@Path("/")
+@Path(ServicePaths.ROOT)
 public class Root {
 	
 	//TODO NOW show git commit
@@ -35,9 +37,9 @@ public class Root {
 	@Produces(MediaType.APPLICATION_JSON)
 	public Map<String, Object> rootJSON() {
 		return ImmutableMap.of(
-				"servername", SERVER_NAME,
-				"version", VERSION,
-				"servertime", Instant.now().toEpochMilli());
+				Fields.SERVER_NAME, SERVER_NAME,
+				Fields.VERSION, VERSION,
+				Fields.SERVER_TIME, Instant.now().toEpochMilli());
 	}
 
 }

--- a/src/us/kbase/genehomology/service/api/ServicePaths.java
+++ b/src/us/kbase/genehomology/service/api/ServicePaths.java
@@ -1,0 +1,36 @@
+package us.kbase.genehomology.service.api;
+
+/** Paths to service endpoints.
+ * @author gaprice@lbl.gov
+ *
+ */
+public class ServicePaths {
+
+	/* general strings */
+
+	/** The URL path separator. */
+	public static final String SEP = "/";
+	
+	private static final String NAMESPACE = "namespace";
+	private static final String NAMESPACE_ID = "{" + NAMESPACE + "}";
+	private static final String SEARCH = "search";
+	
+	
+	/* Root endpoint */
+
+	/** The root endpoint location. */
+	public static final String ROOT = SEP;
+	
+	/* Namespaces */
+	
+	/** The root namespace location. */
+	public static final String NAMESPACE_ROOT = SEP + NAMESPACE;
+	/** The location for a specific namespace. */
+	public static final String NAMESPACE_SELECT = NAMESPACE_ID;
+	/** The parameter name for the namespace selector portion of the url. */
+	public static final String NAMESPACE_SELECT_PARAM = NAMESPACE;
+	/** The location for searching a namespace with a sketch file. */
+	public static final String NAMESPACE_SEARCH = NAMESPACE_SELECT + SEP + SEARCH;
+	
+	
+}

--- a/src/us/kbase/genehomology/service/exceptions/ExceptionHandler.java
+++ b/src/us/kbase/genehomology/service/exceptions/ExceptionHandler.java
@@ -12,9 +12,10 @@ import org.slf4j.LoggerFactory;
 import com.google.common.collect.ImmutableMap;
 
 import us.kbase.genehomology.service.SLF4JAutoLogger;
+import us.kbase.genehomology.service.Fields;
 
 
-/** Handler for exceptions thrown by the Assembly Homology service.
+/** Handler for exceptions thrown by the Gene Homology service.
  * @author gaprice@lbl.gov
  *
  */
@@ -46,7 +47,7 @@ public class ExceptionHandler implements ExceptionMapper<Throwable> {
 		final ErrorMessage em = new ErrorMessage(ex, logger.getCallID(), clock.instant());
 		return Response
 				.status(em.getHttpcode())
-				.entity(ImmutableMap.of("error", em)) //TODO NOW put "error" in a field
+				.entity(ImmutableMap.of(Fields.ERROR, em))
 				.type(MediaType.APPLICATION_JSON)
 				.build();
 	}


### PR DESCRIPTION
Namespace and DB is hardcoded, need to make configurable.

Example usage:
```
curl -X POST -T UniRef50_A0A257EYX4.fasta http://localhost:20003/namespace/testns/search | python -mjson.tool
```